### PR TITLE
Update map-services.xml added info for OpenAIP - Y TSM Format

### DIFF
--- a/data/map-services.xml
+++ b/data/map-services.xml
@@ -257,7 +257,7 @@
 
 	<_overlay_service>
 		<name>AIP</name>
-		<comment>Y UNKNOWN-FORMAT: FFM: http://2.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@png/10/537/676.png</comment>
+		<comment>Map is in TSM Format. y begins from south to north instead from north to south.You have to invert tile y origin from top to bottom of map. var z = tile.levelOfDetail; var ymax = 1 << z; var y = ymax - tile.y - 1; |Y UNKNOWN-FORMAT: FFM: http://2.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@png/10/537/676.png</comment>
 		<url>http://2.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@png/%i/%i/%i.png</url>
 		<file>%s/MAPS/omap_precipitation_%i_%i_%i.png</file>
 		<type>ZXY</type>


### PR DESCRIPTION
OpenAIP uses TSM Format. y begins from south to north instead from north to south.You have to invert tile y origin from top to bottom of map. In JS eg. with:
var z = tile.levelOfDetail;
var ymax = 1 << z;
var y = ymax - tile.y - 1;
